### PR TITLE
update to beta04

### DIFF
--- a/FoldingVideo/app/build.gradle
+++ b/FoldingVideo/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.example.foldingvideo"
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 2
-        versionName "2.0"
+        versionCode 3
+        versionName "3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -37,11 +37,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0-alpha02'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.3.0'
 
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0-beta02'
-    implementation 'androidx.window:window:1.0.0-beta02'
+    implementation 'androidx.window:window:1.0.0-beta04'
     implementation 'com.google.android.exoplayer:exoplayer:2.14.0'
 
 

--- a/FoldingVideo/app/src/main/java/com/example/foldingvideo/MainActivity.kt
+++ b/FoldingVideo/app/src/main/java/com/example/foldingvideo/MainActivity.kt
@@ -17,8 +17,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.window.layout.DisplayFeature
 import androidx.window.layout.FoldingFeature
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowInfoTracker
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.ui.StyledPlayerControlView
@@ -30,9 +29,7 @@ import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
-    // WM
     private lateinit var motionLayout: MotionLayout
-    private lateinit var windowInfoRep: WindowInfoRepository
 
     // ExoPlayer
     private lateinit var playerView: StyledPlayerView
@@ -80,7 +77,6 @@ class MainActivity : AppCompatActivity() {
             updateSplitControl(lastFoldingFeature)
         }
 
-        windowInfoRep = windowInfoRepository()
         // Create a new coroutine since repeatOnLifecycle is a suspend function
         lifecycleScope.launch(Dispatchers.Main) {
             // The block passed to repeatOnLifecycle is executed when the lifecycle
@@ -89,7 +85,8 @@ class MainActivity : AppCompatActivity() {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 // Safely collect from windowInfoRepo when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
-                windowInfoRep.windowLayoutInfo
+                WindowInfoTracker.getOrCreate(this@MainActivity)
+                    .windowLayoutInfo(this@MainActivity)
                     .collect { newLayoutInfo ->
                         fab.hide()
 

--- a/FoldingVideo/app/src/main/java/com/example/foldingvideo/MainActivity.kt
+++ b/FoldingVideo/app/src/main/java/com/example/foldingvideo/MainActivity.kt
@@ -83,7 +83,7 @@ class MainActivity : AppCompatActivity() {
             // is at least STARTED and is cancelled when the lifecycle is STOPPED.
             // It automatically restarts the block when the lifecycle is STARTED again.
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // Safely collect from windowInfoRepo when the lifecycle is STARTED
+                // Safely collect from WindowInfoTracker when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
                 WindowInfoTracker.getOrCreate(this@MainActivity)
                     .windowLayoutInfo(this@MainActivity)

--- a/FoldingVideoPlusChat/app/build.gradle
+++ b/FoldingVideoPlusChat/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.example.video_chat_sample"
         minSdkVersion 29
         targetSdkVersion 31
-        versionCode 2
-        versionName "2.0"
+        versionCode 3
+        versionName "3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.14.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0-beta02'
-    implementation 'androidx.window:window:1.0.0-beta02'
+    implementation 'androidx.window:window:1.0.0-beta04'
     implementation "androidx.fragment:fragment-ktx:1.3.4"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0-alpha02'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/FoldingVideoPlusChat/app/src/main/java/com/example/video_chat_sample/MainActivity.kt
+++ b/FoldingVideoPlusChat/app/src/main/java/com/example/video_chat_sample/MainActivity.kt
@@ -71,7 +71,7 @@ class MainActivity : AppCompatActivity() {
             // is at least STARTED and is cancelled when the lifecycle is STOPPED.
             // It automatically restarts the block when the lifecycle is STARTED again.
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // Safely collect from windowInfoRepo when the lifecycle is STARTED
+                // Safely collect from WindowInfoTracker when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
                 WindowInfoTracker.getOrCreate(this@MainActivity)
                     .windowLayoutInfo(this@MainActivity)

--- a/FoldingVideoPlusChat/app/src/main/java/com/example/video_chat_sample/MainActivity.kt
+++ b/FoldingVideoPlusChat/app/src/main/java/com/example/video_chat_sample/MainActivity.kt
@@ -19,8 +19,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.window.layout.DisplayFeature
 import androidx.window.layout.FoldingFeature
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowInfoTracker
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.ui.StyledPlayerControlView
@@ -32,7 +31,6 @@ import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
     private lateinit var rootView: MotionLayout
-    private lateinit var windowInfoRep: WindowInfoRepository
     private lateinit var endChatView: View
     private lateinit var bottomChatView: View
     private val handler = Handler(Looper.getMainLooper())
@@ -52,8 +50,6 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialize Window Manager
-        windowInfoRep = windowInfoRepository()
         setContentView(R.layout.activity_main)
 
         rootView = findViewById(R.id.root)
@@ -77,7 +73,8 @@ class MainActivity : AppCompatActivity() {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 // Safely collect from windowInfoRepo when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
-                windowInfoRep.windowLayoutInfo
+                WindowInfoTracker.getOrCreate(this@MainActivity)
+                    .windowLayoutInfo(this@MainActivity)
                     .collect { newLayoutInfo ->
                         spanToggle = false
 

--- a/PhotoEditor/app/build.gradle
+++ b/PhotoEditor/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "com.microsoft.device.display.wm_samples.photoeditor"
         minSdkVersion 29
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "2.0"
+        versionCode 3
+        versionName "3.0"
 
         testInstrumentationRunner config.testInstrumentationRunner
     }

--- a/PhotoEditor/app/src/main/java/com/microsoft/device/display/wm_samples/photoeditor/MainActivity.kt
+++ b/PhotoEditor/app/src/main/java/com/microsoft/device/display/wm_samples/photoeditor/MainActivity.kt
@@ -42,8 +42,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.window.layout.FoldingFeature
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowInfoTracker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -61,7 +60,6 @@ private const val DEFAULT_PROGRESS = 50
 
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var windowInfoRep: WindowInfoRepository
     private lateinit var viewModel: PhotoEditorViewModel
     private lateinit var image: ImageFilterView
     private lateinit var saturation: SeekBar
@@ -81,9 +79,6 @@ class MainActivity : AppCompatActivity() {
 
         viewModel = ViewModelProvider(this).get(PhotoEditorViewModel::class.java)
 
-        // Layout based setup
-        windowInfoRep = windowInfoRepository()
-
         primaryContainer = findViewById(R.id.primary_fragment_container)
         secondaryContainer = findViewById(R.id.secondary_fragment_container)
         mainContainer = findViewById(R.id.main_container)
@@ -94,9 +89,10 @@ class MainActivity : AppCompatActivity() {
             // is at least STARTED and is cancelled when the lifecycle is STOPPED.
             // It automatically restarts the block when the lifecycle is STARTED again.
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // Safely collect from windowInfoRepo when the lifecycle is STARTED
+                // Safely collect from windowInfoTracker when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
-                windowInfoRep.windowLayoutInfo
+                WindowInfoTracker.getOrCreate(this@MainActivity)
+                .windowLayoutInfo(this@MainActivity)
                     .collect { newLayoutInfo ->
                         viewModel.isDualScreen = false
 

--- a/PhotoEditor/app/src/main/java/com/microsoft/device/display/wm_samples/photoeditor/MainActivity.kt
+++ b/PhotoEditor/app/src/main/java/com/microsoft/device/display/wm_samples/photoeditor/MainActivity.kt
@@ -92,7 +92,7 @@ class MainActivity : AppCompatActivity() {
                 // Safely collect from windowInfoTracker when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
                 WindowInfoTracker.getOrCreate(this@MainActivity)
-                .windowLayoutInfo(this@MainActivity)
+                    .windowLayoutInfo(this@MainActivity)
                     .collect { newLayoutInfo ->
                         viewModel.isDualScreen = false
 

--- a/PhotoEditor/dependencies.gradle
+++ b/PhotoEditor/dependencies.gradle
@@ -12,7 +12,6 @@ ext {
     minSdkVersion = compileSdkVersion
 
     config = [
-            duoSdkVersion            : "1.0.0-beta1",
             gradlePlugin             : "com.android.tools.build:gradle:$gradlePluginVersion",
             kotlinGradlePlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
             testInstrumentationRunner: "androidx.test.runner.AndroidJUnitRunner"
@@ -30,7 +29,7 @@ ext {
     ktxCoreVersion = "1.5.0"
     ktxFragmentVersion = "1.3.6"
     viewPager2Version = "1.0.0"
-    windowManagerVersion = "1.0.0-beta02"
+    windowManagerVersion = "1.0.0-beta04"
 
     androidxDependencies = [
             appCompat       : "androidx.appcompat:appcompat:$appCompatVersion",

--- a/SourceEditor/app/build.gradle
+++ b/SourceEditor/app/build.gradle
@@ -1,7 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
- *
  */
 
 apply plugin: 'com.android.application'
@@ -12,18 +11,23 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
     defaultConfig {
         applicationId 'com.microsoft.device.display.wm_samples.sourceeditor'
         minSdkVersion 29
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "2.0"
+        versionCode 3
+        versionName "3.0"
 
         testInstrumentationRunner config.testInstrumentationRunner
+    }
+    
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 

--- a/SourceEditor/app/src/main/java/com/microsoft/device/display/wm_samples/sourceeditor/MainActivity.kt
+++ b/SourceEditor/app/src/main/java/com/microsoft/device/display/wm_samples/sourceeditor/MainActivity.kt
@@ -24,8 +24,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.window.layout.FoldingFeature
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowInfoTracker
 import com.microsoft.device.display.wm_samples.sourceeditor.includes.FileHandler
 import com.microsoft.device.display.wm_samples.sourceeditor.viewmodel.DualScreenViewModel
 import com.microsoft.device.display.wm_samples.sourceeditor.viewmodel.WebViewModel
@@ -34,8 +33,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
-    private lateinit var windowInfoRep: WindowInfoRepository
-
+    
     private lateinit var fileBtn: ImageView
     private lateinit var saveBtn: ImageView
 
@@ -52,7 +50,6 @@ class MainActivity : AppCompatActivity() {
         fileHandler = FileHandler(this, webVM, contentResolver)
 
         // Layout based setup
-        windowInfoRep = windowInfoRepository()
         dualScreenVM = ViewModelProvider(this).get(DualScreenViewModel::class.java)
         dualScreenVM.setIsDualScreen(false) // assume single screen on startup
 
@@ -78,9 +75,10 @@ class MainActivity : AppCompatActivity() {
             // is at least STARTED and is cancelled when the lifecycle is STOPPED.
             // It automatically restarts the block when the lifecycle is STARTED again.
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // Safely collect from windowInfoRepo when the lifecycle is STARTED
+                // Safely collect from windowInfoTracker when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
-                windowInfoRep.windowLayoutInfo
+                WindowInfoTracker.getOrCreate(this@MainActivity)
+                    .windowLayoutInfo(this@MainActivity)
                     .collect { newLayoutInfo ->
                         var isDualScreen = false
 

--- a/SourceEditor/app/src/main/java/com/microsoft/device/display/wm_samples/sourceeditor/MainActivity.kt
+++ b/SourceEditor/app/src/main/java/com/microsoft/device/display/wm_samples/sourceeditor/MainActivity.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
-    
+
     private lateinit var fileBtn: ImageView
     private lateinit var saveBtn: ImageView
 

--- a/SourceEditor/dependencies.gradle
+++ b/SourceEditor/dependencies.gradle
@@ -31,7 +31,7 @@ ext {
     ktxCoreVersion = "1.5.0"
     ktxFragmentVersion = "1.3.6"
     viewPager2Version = "1.0.0"
-    windowManagerVersion = "1.0.0-beta02"
+    windowManagerVersion = "1.0.0-beta04"
 
     androidxDependencies = [
             appCompat       : "androidx.appcompat:appcompat:$appCompatVersion",

--- a/TwoNote/app/build.gradle
+++ b/TwoNote/app/build.gradle
@@ -13,16 +13,12 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
     defaultConfig {
         applicationId "com.microsoft.device.display.wm_samples.twonote"
         minSdkVersion 29
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "2.0"
+        versionCode 3
+        versionName "3.0"
 
         testInstrumentationRunner config.testInstrumentationRunner
     }

--- a/TwoNote/app/src/main/java/com/microsoft/device/display/wm_samples/twonote/MainActivity.kt
+++ b/TwoNote/app/src/main/java/com/microsoft/device/display/wm_samples/twonote/MainActivity.kt
@@ -26,8 +26,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.window.layout.FoldingFeature
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowInfoTracker
 import com.microsoft.device.display.wm_samples.twonote.fragments.GetStartedFragment
 import com.microsoft.device.display.wm_samples.twonote.fragments.NoteDetailFragment
 import com.microsoft.device.display.wm_samples.twonote.fragments.NoteListFragment
@@ -65,9 +64,6 @@ class MainActivity :
         }
     }
 
-    // Jetpack Window Manager
-    private lateinit var windowInfoRep: WindowInfoRepository
-
     private var savedNote: Note? = null
     private var savedINode: INode? = null
     private var dualScreenVM = DualScreenViewModel()
@@ -83,17 +79,16 @@ class MainActivity :
         savedNote = savedInstanceState?.getSerializable(NOTE) as? Note
         savedINode = savedInstanceState?.getSerializable(INODE) as? INode
 
-        // Layout based setup
-        windowInfoRep = windowInfoRepository()
         // Create a new coroutine since repeatOnLifecycle is a suspend function
         lifecycleScope.launch(Dispatchers.Main) {
             // The block passed to repeatOnLifecycle is executed when the lifecycle
             // is at least STARTED and is cancelled when the lifecycle is STOPPED.
             // It automatically restarts the block when the lifecycle is STARTED again.
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                // Safely collect from windowInfoRepo when the lifecycle is STARTED
+                // Safely collect from WindowInfoTracker when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED
-                windowInfoRep.windowLayoutInfo
+                WindowInfoTracker.getOrCreate(this@MainActivity)
+                    .windowLayoutInfo(this@MainActivity)
                     .collect { newLayoutInfo ->
                         dualScreenVM.isDualScreen = false
                         var noteSelected = savedNote != null && savedINode != null

--- a/TwoNote/dependencies.gradle
+++ b/TwoNote/dependencies.gradle
@@ -32,7 +32,7 @@ ext {
     ktxCoreVersion = '1.3.2'
     ktxFragmentVersion = '1.3.6'
     ktxLifecycleVersion = '2.4.0-alpha03'
-    windowManagerVersion = "1.0.0-beta02"
+    windowManagerVersion = "1.0.0-beta04"
 
     androidxDependencies = [
             appCompat       : "androidx.appcompat:appcompat:$appCompatVersion",


### PR DESCRIPTION
Update samples to [Jetpack Window Manager **beta04**](https://developer.android.com/jetpack/androidx/releases/window#1.0.0-beta04):

- [ ] eBookReader ^
- [x] FoldingVideo
- [x] FoldingVideoPlusChat
- [x] PhotoEditor
- [x] SourceEditor
- [ ] TravelPlanner ^
- [ ] TwoDo ^
- [x] TwoNote

^ three samples use `slidingpanelayout:1.2.0-beta01` which is still dependent on an earlier version of JWM (1.0.0-beta02) and cannot be updated until a new SlidingPaneLayout is available that's based on JWM beta04.