### PR TITLE
update to 1.0.0 stable release

### DIFF
--- a/EBookReader/app/build.gradle
+++ b/EBookReader/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.microsoft.device.wm_samples.ebook_reader_sample"
         minSdkVersion 21
         targetSdkVersion 31
-        versionCode 3
-        versionName "3.0"
+        versionCode 4
+        versionName "4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0-rc01"
+    implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.5.0'
@@ -41,7 +41,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.4.0'
     implementation "androidx.viewpager2:viewpager2:1.0.0"
-    implementation 'androidx.window:window:1.0.0-rc01'
+    implementation 'androidx.window:window:1.0.0'
     implementation 'com.microsoft.design:fluent-system-icons:1.1.135'
 
     testImplementation 'junit:junit:4.13.2'

--- a/FoldingVideo/app/build.gradle
+++ b/FoldingVideo/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.example.foldingvideo"
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 4
-        versionName "4.0"
+        versionCode 5
+        versionName "5.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -40,7 +40,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
 
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
-    implementation 'androidx.window:window:1.0.0-rc01'
+    implementation 'androidx.window:window:1.0.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.14.0'
 
 

--- a/FoldingVideoPlusChat/app/build.gradle
+++ b/FoldingVideoPlusChat/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.example.video_chat_sample"
         minSdkVersion 29
         targetSdkVersion 31
-        versionCode 4
-        versionName "4.0"
+        versionCode 5
+        versionName "5.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -42,7 +42,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.14.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
-    implementation 'androidx.window:window:1.0.0-rc01'
+    implementation 'androidx.window:window:1.0.0'
     implementation "androidx.fragment:fragment-ktx:1.3.4"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/PhotoEditor/app/build.gradle
+++ b/PhotoEditor/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "com.microsoft.device.display.wm_samples.photoeditor"
         minSdkVersion 29
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4
-        versionName "4.0"
+        versionCode 5
+        versionName "5.0"
 
         testInstrumentationRunner config.testInstrumentationRunner
     }

--- a/PhotoEditor/dependencies.gradle
+++ b/PhotoEditor/dependencies.gradle
@@ -29,7 +29,7 @@ ext {
     ktxCoreVersion = "1.5.0"
     ktxFragmentVersion = "1.3.6"
     viewPager2Version = "1.0.0"
-    windowManagerVersion = "1.0.0-rc01"
+    windowManagerVersion = "1.0.0"
 
     androidxDependencies = [
             appCompat       : "androidx.appcompat:appcompat:$appCompatVersion",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Jetpack Window Manager samples for dual-screen and foldable devices like Microsoft Surface Duo
 
-Android app samples that use [Jetpack Window Manager](https://docs.microsoft.com/dual-screen/android/platform/jetpack-window-manager) to support dual-screen and foldable devices.
+Android app samples that use [Jetpack Window Manager](https://docs.microsoft.com/dual-screen/android/jetpack/window-manager/) to support dual-screen and foldable devices. Projects are updated to the [1.0.0 release](https://developer.android.com/jetpack/androidx/releases/window) of Window Manager.
+
+- eBookReader
+- FoldingVideo
+- FoldingVideoWithChat
+- PhotoEditor
+- SourceEditor
+- TravelPlanner
+- TwoDo
+- TwoNote
 
 ## Related links
 

--- a/SourceEditor/app/build.gradle
+++ b/SourceEditor/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId 'com.microsoft.device.display.wm_samples.sourceeditor'
         minSdkVersion 29
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4
-        versionName "4.0"
+        versionCode 5
+        versionName "5.0"
 
         testInstrumentationRunner config.testInstrumentationRunner
     }

--- a/SourceEditor/dependencies.gradle
+++ b/SourceEditor/dependencies.gradle
@@ -31,7 +31,7 @@ ext {
     ktxCoreVersion = "1.5.0"
     ktxFragmentVersion = "1.3.6"
     viewPager2Version = "1.0.0"
-    windowManagerVersion = "1.0.0-rc01"
+    windowManagerVersion = "1.0.0"
 
     androidxDependencies = [
             appCompat       : "androidx.appcompat:appcompat:$appCompatVersion",

--- a/TravelPlanner/app/build.gradle
+++ b/TravelPlanner/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "com.example.travelplanner"
         minSdkVersion 29 // was 24
         targetSdkVersion 31
-        versionCode 2
-        versionName "2.0"
+        versionCode 3
+        versionName "3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -48,7 +48,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.5.0-rc01'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
-    implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0-rc01"
+    implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0"
     implementation "androidx.fragment:fragment-ktx:1.3.6"
     implementation 'com.microsoft.design:fluent-system-icons:1.1.134@aar'
 

--- a/TwoDo/app/build.gradle
+++ b/TwoDo/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId 'com.microsoft.device.wm_samples.twodo'
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 3
-        versionName "3.0"
+        versionCode 4
+        versionName "4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -41,8 +41,8 @@ dependencies {
 //    def slidingpanelayout_version = '1.2.0-SNAPSHOT'
 //    implementation "androidx.slidingpanelayout:slidingpanelayout:$slidingpanelayout_version"
 
-    implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0-rc01"
-    implementation 'androidx.window:window:1.0.0-rc01'
+    implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0"
+    implementation 'androidx.window:window:1.0.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.core:core-ktx:1.6.0"

--- a/TwoNote/app/build.gradle
+++ b/TwoNote/app/build.gradle
@@ -17,8 +17,8 @@ android {
         applicationId "com.microsoft.device.display.wm_samples.twonote"
         minSdkVersion 29
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4
-        versionName "4.0"
+        versionCode 5
+        versionName "5.0"
 
         testInstrumentationRunner config.testInstrumentationRunner
     }

--- a/TwoNote/dependencies.gradle
+++ b/TwoNote/dependencies.gradle
@@ -32,7 +32,7 @@ ext {
     ktxCoreVersion = '1.3.2'
     ktxFragmentVersion = '1.3.6'
     ktxLifecycleVersion = '2.4.0'
-    windowManagerVersion = "1.0.0-rc01"
+    windowManagerVersion = "1.0.0"
 
     androidxDependencies = [
             appCompat       : "androidx.appcompat:appcompat:$appCompatVersion",


### PR DESCRIPTION
and slidingpanelayout-1.2.0 stable release

Update samples to [Jetpack Window Manager **1.0.0**](https://developer.android.com/jetpack/androidx/releases/window#1.0.0):

- [x] eBookReader ^
- [x] FoldingVideo
- [ ] FoldingVideoPlusChat
- [ ] PhotoEditor
- [x] SourceEditor
- [ ] TravelPlanner ^
- [x] TwoDo ^
- [ ] TwoNote

^ these samples were also updated with SlidingPaneLayout to 1.2.0